### PR TITLE
Trigger Woodpecker builds automatically on push to master

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,8 +1,15 @@
 when:
-  # Drone's trigger was `event: [custom]` only - no push-triggered builds.
-  # Woodpecker has no direct "custom" event; "manual" is the equivalent
-  # (API/UI-triggered only), so that behavior carries over unchanged.
-  - event: manual
+  # Matches docker-rickroll/docker-starwars: push-triggered on master,
+  # scoped to what actually gets COPYed into the image in the Dockerfile,
+  # plus manual for on-demand rebuilds.
+  - event: [push, manual]
+    branch: master
+    path:
+      include:
+        - Dockerfile
+        - src/**
+        - conf/nginx-site.conf
+        - .woodpecker.yml
 
 steps:
   - name: lint-dockerfile

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ confirms the countdown actually rolls over to "Happy New Year!". See
 `.github/workflows/test.yml` if you want the gory details.
 
 `.woodpecker.yml` does the actual multi-arch build and Docker Hub push,
-triggered manually (e.g. after a merge to `master`) rather than automatically
-on push.
+triggered automatically on push to `master` (or manually, for on-demand
+rebuilds).
 
 ## Tags
 


### PR DESCRIPTION
## Summary
- Changes `.woodpecker.yml`'s trigger from `event: manual` (inherited from the Drone migration) to `event: [push, manual]` scoped to `branch: master` with a path filter limited to what's actually copied into the image (`Dockerfile`, `src/**`, `conf/nginx-site.conf`, `.woodpecker.yml`) — matches `docker-rickroll`/`docker-starwars`
- Updates README's Testing/CI wording to match (push-triggered, not manual-only)

## Test plan
- [x] `.woodpecker.yml` validated as syntactically valid YAML
- [ ] First push-triggered Woodpecker build succeeds after merge